### PR TITLE
Wait for API key before initializing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,8 +29,6 @@ export default class VaultChat extends Plugin {
 
 	waitingForApiKey: boolean;
 
-	pluginInitialized = false;
-
 	async onload() {
 		await this.loadSettings();
 
@@ -40,7 +38,6 @@ export default class VaultChat extends Plugin {
 		this.waitingForApiKey = !this.apiKeyIsValid()
 
 		if (this.waitingForApiKey) {
-			this.waitingForApiKey = true;
 			console.warn('Vault Chat plugin requires you to set your OpenAI API key in the plugin settings, ' +
 				'but it appears you have not set one. Until you do, Vault Chat plugin will remain inactive.')
 		} else {
@@ -59,7 +56,6 @@ export default class VaultChat extends Plugin {
 	}
 
 	initializePlugin() {
-		if (this.pluginInitialized) return
 		this.openAIHandler = new OpenAIHandler(this.settings.apiKey)
 		this.vectorStore = new VectorStore(this.app.vault)
 		this.vectorStore.isReady.then(async () => {
@@ -156,6 +152,7 @@ export default class VaultChat extends Plugin {
 	async saveSettings() {
 		await this.saveData(this.settings);
 		if (this.waitingForApiKey && this.apiKeyIsValid()) {
+			this.waitingForApiKey = false
 			this.initializePlugin()
 		}
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ export default class VaultChat extends Plugin {
 
 	searchTerm: string;
 
-	searchActive: boolean = false;
+	searchActive = false;
 
 	vectorStore: VectorStore;
 
@@ -29,7 +29,7 @@ export default class VaultChat extends Plugin {
 
 	waitingForApiKey: boolean;
 
-	pluginInitialized: boolean = false;
+	pluginInitialized = false;
 
 	async onload() {
 		await this.loadSettings();
@@ -140,7 +140,7 @@ export default class VaultChat extends Plugin {
 			if (fileContents.length > 1000) {
 				fileContents = `${fileContents.substring(0, 1000)}...`
 			}
-			const fileName = searchResult.split('/').last()!!
+			const fileName = searchResult.split('/').last()!
 			hydratedResults.push({
 				name: fileName,
 				contents: fileContents,

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,13 +35,13 @@ export default class VaultChat extends Plugin {
 		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.addSettingTab(new VaultChatSettingTab(this.app, this));
 
-		this.waitingForApiKey = !this.apiKeyIsValid()
-
-		if (this.waitingForApiKey) {
+		if (this.apiKeyIsValid()) {
+			this.waitingForApiKey = false
+			this.initializePlugin()
+		} else {
+			this.waitingForApiKey = true
 			console.warn('Vault Chat plugin requires you to set your OpenAI API key in the plugin settings, ' +
 				'but it appears you have not set one. Until you do, Vault Chat plugin will remain inactive.')
-		} else {
-			this.initializePlugin()
 		}
 	}
 


### PR DESCRIPTION
**Before:** When you first add the plugin and enable it, it immediately starts trying to index the vault even though you have not set your API key in the setting pane yet. This results in a bunch of 401s, and also interferes with your vault indexing successfully once you do input your API key.

**After:** If your API key is blank, or really short, don't set up anything but the setting panel. Once the API key is entered, initialize the plugin interactions. 