### PR TITLE
Adds hyde prompts for Ask ChatGPT command

### DIFF
--- a/src/VectorStore.ts
+++ b/src/VectorStore.ts
@@ -303,43 +303,6 @@ export class VectorStore {
 		return new Map(dbFile.embeddings)
 	}
 
-	getNearestVectors(searchVector: Vector, resultNumber: number, relevanceThreshold: number): NearestVectorResult[] {
-		const nearestVectors: NearestVectorResult[] = []
-
-		for (const entry of this.embeddings.entries()) {
-			const filePath = entry[0]
-			const fileEntry = entry[1]
-			if (fileEntry.embedding && fileEntry.embedding.length) {
-				const fileSimilarity = similarity(searchVector, fileEntry.embedding)
-				nearestVectors.push({
-					path: filePath,
-					chunk: undefined,
-					similarity: fileSimilarity
-				})
-			}
-			fileEntry.chunks.forEach(chunk => {
-				if (chunk.embedding && chunk.embedding.length) {
-					const chunkSimilarity = similarity(searchVector, chunk.embedding)
-					nearestVectors.push({
-						path: filePath,
-						chunk: chunk.contents,
-						similarity: chunkSimilarity
-					})
-				}
-			})
-		}
-
-		nearestVectors.sort((a, b) => {
-			const aEmbedding = a.similarity
-			const bEmbedding = b.similarity
-			return aEmbedding > bEmbedding ? -1: 1
-		})
-
-		return nearestVectors
-			.splice(0, resultNumber)
-			.filter(e => e.similarity > relevanceThreshold)
-	}
-
 	private similarityBatch(searchVectors: Vector[], possibleMatch: Vector): number {
 		let highestSimilarity = similarity(searchVectors.first(), possibleMatch)
 		for (const searchVector of searchVectors) {

--- a/src/VectorStore.ts
+++ b/src/VectorStore.ts
@@ -303,7 +303,7 @@ export class VectorStore {
 		return new Map(dbFile.embeddings)
 	}
 
-	private similarityBatch(searchVectors: Vector[], possibleMatch: Vector): number {
+	private computeSimilarity(searchVectors: Vector[], possibleMatch: Vector): number {
 		let highestSimilarity = similarity(searchVectors.first(), possibleMatch)
 		for (const searchVector of searchVectors) {
 			const currentSimilarity = similarity(searchVector, possibleMatch)
@@ -314,14 +314,14 @@ export class VectorStore {
 		return highestSimilarity
 	}
 
-	getNearestVectorsBatch(searchVectors: Vector[], resultNumber: number, relevanceThreshold: number): NearestVectorResult[] {
+	getNearestVectors(searchVectors: Vector[], resultNumber: number, relevanceThreshold: number): NearestVectorResult[] {
 		const nearestVectors: NearestVectorResult[] = []
 
 		for (const entry of this.embeddings.entries()) {
 			const filePath = entry[0]
 			const fileEntry = entry[1]
 			if (fileEntry.embedding && fileEntry.embedding.length) {
-				const fileSimilarity = this.similarityBatch(searchVectors, fileEntry.embedding)
+				const fileSimilarity = this.computeSimilarity(searchVectors, fileEntry.embedding)
 				nearestVectors.push({
 					path: filePath,
 					chunk: undefined,
@@ -330,7 +330,7 @@ export class VectorStore {
 			}
 			fileEntry.chunks.forEach(chunk => {
 				if (chunk.embedding && chunk.embedding.length) {
-					const chunkSimilarity = this.similarityBatch(searchVectors, chunk.embedding)
+					const chunkSimilarity = this.computeSimilarity(searchVectors, chunk.embedding)
 					nearestVectors.push({
 						path: filePath,
 						chunk: chunk.contents,

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,19 +125,6 @@ export default class VaultChat extends Plugin {
 	onunload() {
 	}
 
-	async searchForTerm(searchTerm: string): Promise<Array<string>> {
-		if (searchTerm === '') {
-			return []
-		}
-		const embedding = await this.openAIHandler.createEmbedding(searchTerm)
-		if (embedding === undefined) {
-			console.error(`Failed to generate vector for search term.`)
-			return []
-		}
-		const nearest: NearestVectorResult[] = this.vectorStore.getNearestVectors(embedding, 3, this.settings.relevanceThreshold)
-		return nearest.map(n => n.path)
-	}
-
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,7 +138,7 @@ export default class VaultChat extends Plugin {
 	}
 
 	async askChatGpt(question: string) {
-		// HyDE: request note that answers the question
+		// HyDE: request note that answers the question https://github.com/texttron/hyde
 		const conversation: Array<ChatCompletionRequestMessage> = []
 		const hydeMessage: ChatCompletionRequestMessage = {
 			role: ChatCompletionResponseMessageRoleEnum.User,
@@ -154,10 +154,10 @@ export default class VaultChat extends Plugin {
 		// create embeddings for that note and all of its blocks
 		const hydeNote = hydeResponse.choices[0].message.content
 		const hydeNoteBlocks = parseMarkdown(hydeNote, '')
-		const hydeBlocksStrings = hydeNoteBlocks.map(t => `${t.path} ${t.localHeading} ${t.content}`)
-		hydeBlocksStrings.push(hydeNote)
-		hydeBlocksStrings.push(question) // include the users raw question
-		const embeddingsResponse = await this.openAIHandler.createEmbeddingBatch(hydeBlocksStrings)
+		const queryBlockStrings = hydeNoteBlocks.map(t => `${t.path} ${t.localHeading} ${t.content}`)
+		queryBlockStrings.push(hydeNote)
+		queryBlockStrings.push(question) // include the users raw question
+		const embeddingsResponse = await this.openAIHandler.createEmbeddingBatch(queryBlockStrings)
 		const embeddings = embeddingsResponse?.data
 		if (!embeddings) {
 			console.error(`Failed to get embeddings for hyde response`)
@@ -165,7 +165,7 @@ export default class VaultChat extends Plugin {
 		}
 		const searchVectors = embeddings.map(e => e.embedding)
 		// search for matches
-		const nearestVectors = this.vectorStore.getNearestVectorsBatch(searchVectors, 8, this.settings.relevanceThreshold)
+		const nearestVectors = this.vectorStore.getNearestVectors(searchVectors, 8, this.settings.relevanceThreshold)
 		const results = await Promise.all(nearestVectors.map(async (nearest, i) => {
 			let name = nearest.path.split('/').last() || ''
 			let contents = nearest.chunk


### PR DESCRIPTION
https://arxiv.org/pdf/2212.10496.pdf

When you ask chatgpt a question, now we:
- ask chatgpt to generate a markdown note that would answer the question via completions
- parse the note chatgpt writes into blocks
- generate embeddings for the hyde note, all its blocks, and the original question
- compare vectors for all of the above to vectors from your vault
- use the top 8 matches as context for your question to chatgpt