### PR TITLE
Enforce 30s timeout on OpenAI calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vault-chat",
-	"version": "1.0.6",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vault-chat",
-			"version": "1.0.6",
+			"version": "1.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"compute-cosine-similarity": "^1.0.0",
@@ -15,6 +15,7 @@
 				"limiter": "^2.1.0",
 				"mathjs": "^11.5.1",
 				"openai": "^3.2.1",
+				"p-timeout": "^6.1.1",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"remarkable": "^2.0.1",
@@ -2069,6 +2070,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-timeout": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+			"integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w==",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4012,6 +4024,11 @@
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
+		},
+		"p-timeout": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
+			"integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w=="
 		},
 		"parent-module": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"limiter": "^2.1.0",
 		"mathjs": "^11.5.1",
 		"openai": "^3.2.1",
+		"p-timeout": "^6.1.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"remarkable": "^2.0.1",


### PR DESCRIPTION
Main purpose of PR: Enforce 30s timeout on OpenAI calls
Additional bug fixes:
- VectorStore L95: Should exit indexing function if there is nothing to update
- VectorStore L157: Chunk contents weren't being saved to db file
- VectorStore L392: Last batch was being dropped in batchArrayByTokenCount